### PR TITLE
Validate batch size in batch utility

### DIFF
--- a/packages/async/src/batch.ts
+++ b/packages/async/src/batch.ts
@@ -17,6 +17,9 @@ export async function batch<T>(
   size = 5
 ): Promise<void> {
   if (!values.length) return;
+  if (size < 1) {
+    throw new RangeError("Batch size must be at least 1");
+  }
 
   diag.log(`Batch_${name}`, values.length);
 

--- a/packages/async/test/batch.test.ts
+++ b/packages/async/test/batch.test.ts
@@ -47,6 +47,14 @@ describe("Async/Batch", () => {
     callCounts(0, 0, 0);
   });
 
+  test("batch: invalid size", async () => {
+    await assert.rejects(batch("invalid", [1], batchFn, 0), {
+      name: "RangeError",
+      message: "Batch size must be at least 1",
+    });
+    callCounts(0, 0, 0);
+  });
+
   const testAr = (count: number, fn?: (i: number) => number) => {
     const ar = Array(count).fill(0);
     return fn ? ar.map((_, i) => fn(i)) : ar;


### PR DESCRIPTION
## Summary
- prevent invalid batch sizes by rejecting values lower than one before processing
- add a unit test that asserts the batch helper rejects an invalid size

## Testing
- `npm run test --workspace packages/async`


------
https://chatgpt.com/codex/tasks/task_e_68cd999e89208333a25b45c130b808ff