### PR TITLE
Fix Gemini thread history for empty prompts

### DIFF
--- a/packages/gemini/src/gemini.ts
+++ b/packages/gemini/src/gemini.ts
@@ -122,7 +122,7 @@ async function apiCall<T extends object>(
   let attempt = 0;
   const [systemPrompt, ...restOfThread] = thread;
   const messages = createMessages(restOfThread, input, context);
-  const newThread = [systemPrompt!, ...messages];
+  const newThread = systemPrompt ? [systemPrompt, ...messages] : messages;
 
   /*
   https://github.com/google-gemini/cookbook/issues/393

--- a/packages/gemini/test/gemini.test.ts
+++ b/packages/gemini/test/gemini.test.ts
@@ -118,6 +118,18 @@ describe("AI: Gemini", () => {
     validateAPIResponse(result, ResponseTemplates["default"]!, "complete");
   });
 
+  test("jsonCompletion preserves thread entries for empty thread", async () => {
+    geminiMock.mockResponseOnce(ResponseTemplates["default"]!);
+    const result = await jsonCall(ParamTemplates["threadArrayEmpty"]!);
+
+    callCounts(defaultLog);
+    assert.ok(result.thread, "thread should be defined");
+    assert.ok(
+      result.thread!.every((message) => message && typeof message.role === "string"),
+      "thread entries should all be Content objects"
+    );
+  });
+
   test("Response Rate Limit", async () => {
     const [error, expected] = RateLimitTemplate;
     geminiMock.mockMany([error, error, error, error]);


### PR DESCRIPTION
## Summary
- avoid inserting undefined system prompts into the Gemini thread history
- add a regression test to ensure jsonCompletion returns only defined Content entries when starting from an empty thread

## Testing
- npm run test --workspace packages/gemini

------
https://chatgpt.com/codex/tasks/task_e_68d8535e5328833385c55b173fda4401