### PR TITLE
Expose Gemini and OpenAI client helpers

### DIFF
--- a/packages/gemini/src/gemini.ts
+++ b/packages/gemini/src/gemini.ts
@@ -179,7 +179,7 @@ async function apiCall<T extends object>(
 }
 
 let _client: GoogleGenAI;
-function getClient() {
+export function getClient() {
   if (!_client) {
     _client = new GoogleGenAI({
       apiKey: process.env["GEMINI_API_KEY"],

--- a/packages/gemini/src/index.ts
+++ b/packages/gemini/src/index.ts
@@ -1,5 +1,5 @@
 export { subscribeGeminiLogging } from "./diagnostics.ts";
 
 export { z } from "zod";
-export { jsonCompletion, proseCompletion } from "./gemini.ts";
+export { getClient, jsonCompletion, proseCompletion } from "./gemini.ts";
 export { zBoolean, zEnum, zNumber, zObj, zObjArray, zString } from "./zod.ts";

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,5 +1,5 @@
 export { subscribeOpenAILogging } from "./diagnostics.ts";
 
 export { z } from "zod";
-export { jsonCompletion, proseCompletion } from "./openai.ts";
+export { getClient, jsonCompletion, proseCompletion } from "./openai.ts";
 export { zBoolean, zEnum, zNumber, zObj, zObjArray, zString } from "./zod.ts";

--- a/packages/openai/src/openai.ts
+++ b/packages/openai/src/openai.ts
@@ -155,7 +155,7 @@ async function apiCall<T extends object>(
 }
 
 let _client: OpenAI;
-function getClient() {
+export function getClient() {
   if (!_client) {
     _client = new OpenAI();
   }


### PR DESCRIPTION
## Summary
- export the internal getClient helper from the Gemini package
- re-export getClient from the Gemini package index for library users
- export and re-export the OpenAI getClient helper in the same manner

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d855cbd95483338788f094be7feb94