### PR TITLE
feat(text): allow markdown conversion customization

### DIFF
--- a/packages/text/src/text.ts
+++ b/packages/text/src/text.ts
@@ -3,28 +3,47 @@ import sanitizeHtml from "sanitize-html";
 import Showdown from "showdown";
 import TurndownService from "turndown";
 
+const defaultShowdownOptions: Showdown.ConverterOptions = {
+  tables: true,
+  disableForced4SpacesIndentedSublists: true,
+  ghCompatibleHeaderId: true,
+};
+
 /**
  * Standardizes untrusted HTML content by converting it to Markdown and then back to sanitized HTML.
  * @param html - The untrusted HTML content
+ * @param converterOptions - Optional Showdown converter options to apply or override defaults
+ * @param turndownOptions - Optional Turndown options to configure markdown conversion
  * @returns The standardized HTML content
  */
-export function standardizeUntrustedHtml(html: string): string {
+export function standardizeUntrustedHtml(
+  html: string,
+  converterOptions?: Showdown.ConverterOptions,
+  turndownOptions?: TurndownService.Options,
+): string {
   const decoded = decode(html);
   const sanitized = sanitizeHtmlContent(decoded);
 
-  const turndownService = new TurndownService();
+  const turndownService = new TurndownService(turndownOptions);
   const markdown = turndownService.turndown(sanitized);
 
-  return markdownToHtml(markdown);
+  return markdownToHtml(markdown, converterOptions);
 }
 
 /**
  * Converts Markdown content to sanitized HTML.
  * @param markdown - The Markdown content
+ * @param options - Optional Showdown converter options to apply or override defaults
  * @returns The sanitized HTML content
  */
-export function markdownToHtml(markdown: string): string {
-  const converter = new Showdown.Converter();
+export function markdownToHtml(
+  markdown: string,
+  options?: Showdown.ConverterOptions,
+): string {
+  const converter = new Showdown.Converter({
+    ...defaultShowdownOptions,
+    ...options,
+  });
   const newHtml = converter.makeHtml(markdown);
 
   return sanitizeHtmlContent(newHtml);

--- a/packages/text/test/text.test.ts
+++ b/packages/text/test/text.test.ts
@@ -15,6 +15,7 @@ const html = {
   headersWithId:
     '<h1 id="header1">Header 1</h1>\n<h2 id="header2">Header 2</h2>',
   list: "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>",
+  nestedList: "<ol>\n<li>Item 1<ul>\n<li>Nested 1</li>\n<li>Nested 2</li></ul></li>\n</ol>",
   codeBlock: "<pre><code>code block\n</code></pre>",
   codeInline: "<p>This is <code>inline code</code></p>",
   linkEmpty: "<a>Text</a>",
@@ -24,6 +25,10 @@ const html = {
   script: "<p>Text</p><script>alert('xss')</script>",
   disallowedAttributes: "<p onclick=\"alert('xss')\">Text</p>",
   disallowedTags: '<p>Text</p><iframe src="https://evil.com"></iframe>',
+  table:
+    "<table>\n<thead>\n<tr>\n<th>H1</th>\n<th>H2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>C1</td>\n<td>C2</td>\n</tr>\n</tbody>\n</table>",
+  tableParagraphs: "<p>H1</p>\n<p>H2</p>\n<p>C1</p>\n<p>C2</p>",
+  blankParagraph: "<p>BLANK</p>",
 };
 
 const markdown = {
@@ -31,10 +36,12 @@ const markdown = {
   bold: "Bold **Text**",
   headers: "# Header 1\n## Header 2",
   list: "- Item 1\n- Item 2",
+  nestedList: "1. Item 1\n   - Nested 1\n   - Nested 2",
   codeBlock: "```\ncode block\n```",
   codeInline: "This is `inline code`",
   link: "[Text](https://example.com)",
   scriptInjection: "[Text](javascript:alert('xss'))",
+  table: "| H1 | H2 |\n| --- | --- |\n| C1 | C2 |",
 };
 
 describe("HtmlDown: sanitizeHtmlContent", () => {
@@ -45,6 +52,7 @@ describe("HtmlDown: sanitizeHtmlContent", () => {
     ["headers", html.headers],
     ["headersWithId", html.headers],
     ["list", html.list],
+    ["nestedList", html.nestedList],
     ["codeBlock", html.codeBlock],
     ["codeInline", html.codeInline],
     ["linkEmpty", html.linkEmpty],
@@ -70,10 +78,12 @@ describe("HtmlDown: markdownToHtml", () => {
     ["bold", html.bold],
     ["headers", html.headers],
     ["list", html.list],
+    ["nestedList", html.nestedList],
     ["codeBlock", html.codeBlock],
     ["codeInline", html.codeInline],
     ["link", `<p>${html.link}</p>`],
     ["scriptInjection", `<p>${html.linkEmpty}</p>`],
+    ["table", html.table],
   ];
 
   cases.forEach(([name, expected]) => {
@@ -81,6 +91,11 @@ describe("HtmlDown: markdownToHtml", () => {
       const result = markdownToHtml(markdown[name]);
       assert.equal(result, expected);
     });
+  });
+
+  test("markdownToHtml: override options", () => {
+    const result = markdownToHtml(markdown.table, { tables: false });
+    assert.equal(result, `<p>${markdown.table}</p>`);
   });
 });
 
@@ -108,5 +123,24 @@ describe("HtmlDown: standardizeUntrustedHtml", () => {
       const result = standardizeUntrustedHtml(encode(html[name]));
       assert.equal(result, expected);
     });
+  });
+
+  test("standardizeUntrustedHtml: converter options override", () => {
+    const result = standardizeUntrustedHtml(
+      encode(html.table),
+      { tables: false },
+    );
+
+    assert.equal(result, html.tableParagraphs);
+  });
+
+  test("standardizeUntrustedHtml: turndown options applied", () => {
+    const result = standardizeUntrustedHtml(
+      encode("<p></p>"),
+      undefined,
+      { blankReplacement: () => "BLANK" },
+    );
+
+    assert.equal(result, html.blankParagraph);
   });
 });


### PR DESCRIPTION
## Summary
- add default Showdown converter options for markdown to HTML conversion
- allow overriding Showdown and Turndown options in `markdownToHtml` and `standardizeUntrustedHtml`
- expand text package tests to cover tables, nested lists, and custom option handling

## Testing
- npm test -- text

------
https://chatgpt.com/codex/tasks/task_e_68d85dd650808333985a3edfd0d03709