### PR TITLE
Allow configuring OpenAI reasoning effort

### DIFF
--- a/packages/openai/test/completionParams.ts
+++ b/packages/openai/test/completionParams.ts
@@ -26,6 +26,7 @@ export interface CompletionParams {
   context?: CompletionOptions["context"];
   tools?: Tool[];
   model?: string;
+  reasoningEffort?: CompletionOptions["reasoningEffort"];
 }
 
 const defaultParams: CompletionParams = {
@@ -104,6 +105,7 @@ export const ParamTemplates: Record<string, CompletionParams> = {
   toolsOne: mp({ tools: fullTools.slice(0, 1) }),
   toolsFull: mp({ tools: fullTools }),
   model: mp({ model: "gpt-5-fake" }),
+  reasoningEffort: mp({ reasoningEffort: "medium" }),
 };
 
 /**
@@ -115,7 +117,16 @@ export function validateAPIParams(
   actual: ResponseCreateParams,
   used: CompletionParams
 ): void {
-  const { action, thread, input, schema, context, tools, model } = used;
+  const {
+    action,
+    thread,
+    input,
+    schema,
+    context,
+    tools,
+    model,
+    reasoningEffort,
+  } = used;
 
   const fullThread: ResponseInputItem[] =
     typeof thread === "string"
@@ -135,6 +146,11 @@ export function validateAPIParams(
     actual.tools,
     tools?.map((x) => toolToOpenAITool(x)) ?? [],
     "tools"
+  );
+  assert.deepEqual(
+    actual.reasoning,
+    reasoningEffort === undefined ? undefined : { effort: reasoningEffort },
+    "reasoning"
   );
 }
 

--- a/packages/openai/test/openai.test.ts
+++ b/packages/openai/test/openai.test.ts
@@ -27,20 +27,36 @@ process.env["OPENAI_API_KEY"] = "mock_openai_key";
 function proseCall(
   params: CompletionParams
 ): Promise<CompletionResponse<string>> {
-  const { action, thread, input, context, tools, model } = params;
+  const { action, thread, input, context, tools, model, reasoningEffort } =
+    params;
 
-  return proseCompletion(action, thread, input, { context, tools, model });
+  return proseCompletion(action, thread, input, {
+    context,
+    tools,
+    model,
+    reasoningEffort,
+  });
 }
 
 function jsonCall(
   params: CompletionParams
 ): Promise<CompletionResponse<unknown>> {
-  const { action, thread, input, schema, context, tools, model } = params;
+  const {
+    action,
+    thread,
+    input,
+    schema,
+    context,
+    tools,
+    model,
+    reasoningEffort,
+  } = params;
 
   return jsonCompletion(action, thread, input, schema, {
     context,
     tools,
     model,
+    reasoningEffort,
   });
 }
 


### PR DESCRIPTION
## Summary
- add a reasoningEffort option to completion helpers so callers control the request payload
- stop hardcoding minimal reasoning effort and propagate the caller-provided value
- extend tests to cover the new option and expectations

## Testing
- npm run test --workspace packages/openai

------
https://chatgpt.com/codex/tasks/task_e_68e57c903b408333b6c8c6502ae5b749