### PR TITLE
Align Gemini reasoning effort handling

### DIFF
--- a/packages/gemini/test/gemini.test.ts
+++ b/packages/gemini/test/gemini.test.ts
@@ -24,20 +24,28 @@ import { MockGeminiClient } from "./mockGeminiClient.ts";
 function proseCall(
   params: CompletionParams
 ): Promise<CompletionResponse<string>> {
-  const { action, thread, input, context, tools, model } = params;
+  const { action, thread, input, context, tools, model, reasoningEffort } =
+    params;
 
-  return proseCompletion(action, thread, input, { context, tools, model });
+  return proseCompletion(action, thread, input, {
+    context,
+    tools,
+    model,
+    reasoningEffort,
+  });
 }
 
 function jsonCall(
   params: CompletionParams
 ): Promise<CompletionResponse<unknown>> {
-  const { action, thread, input, schema, context, tools, model } = params;
+  const { action, thread, input, schema, context, tools, model, reasoningEffort } =
+    params;
 
   return jsonCompletion(action, thread, input, schema, {
     context,
     tools,
     model,
+    reasoningEffort,
   });
 }
 


### PR DESCRIPTION
## Summary
- treat Gemini reasoning efforts with explicit budgets including minimal
- inline the reasoning-to-budget mapping in the Gemini client and expose the option in tests
- extend Gemini test fixtures to cover reasoning budgets and verify the request payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e580eae9208333a697b833e976b311