### PR TITLE
Mock timers for Gemini and OpenAI backoff tests

### DIFF
--- a/packages/gemini/test/gemini.test.ts
+++ b/packages/gemini/test/gemini.test.ts
@@ -1,11 +1,7 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import { beforeEach, describe, mock, test } from "node:test";
 import type { CompletionResponse } from "../src/gemini.ts";
-import {
-  jsonCompletion,
-  proseCompletion,
-  subscribeGeminiLogging,
-} from "../src/index.ts";
 import {
   ParamTemplates,
   validateAPIParams,
@@ -19,7 +15,26 @@ import {
   validateAPIError,
   validateAPIResponse,
 } from "./generateResponse.ts";
-import { MockGeminiClient } from "./mockGeminiClient.ts";
+
+const require = createRequire(import.meta.url);
+const timers = require("node:timers/promises") as typeof import("node:timers/promises");
+const originalSetTimeout = timers.setTimeout;
+timers.setTimeout = (async (
+  _delay: number,
+  value: unknown
+) => value) as typeof timers.setTimeout;
+
+test.after(() => {
+  timers.setTimeout = originalSetTimeout;
+});
+
+const {
+  jsonCompletion,
+  proseCompletion,
+  subscribeGeminiLogging,
+} = await import("../src/index.ts");
+
+const { MockGeminiClient } = await import("./mockGeminiClient.ts");
 
 function proseCall(
   params: CompletionParams

--- a/packages/openai/test/openai.test.ts
+++ b/packages/openai/test/openai.test.ts
@@ -1,10 +1,6 @@
 import assert from "assert/strict";
+import { createRequire } from "node:module";
 import { beforeEach, describe, mock, test } from "node:test";
-import {
-  jsonCompletion,
-  proseCompletion,
-  subscribeOpenAILogging,
-} from "../src/index.ts";
 import type { CompletionResponse } from "../src/openai.ts";
 import {
   ParamErrorTemplates,
@@ -22,7 +18,25 @@ import {
   validateAPIResponse,
 } from "./parsedResponse.ts";
 
+const require = createRequire(import.meta.url);
+const timers = require("node:timers/promises") as typeof import("node:timers/promises");
+const originalSetTimeout = timers.setTimeout;
+timers.setTimeout = (async (
+  _delay: number,
+  value: unknown
+) => value) as typeof timers.setTimeout;
+
+test.after(() => {
+  timers.setTimeout = originalSetTimeout;
+});
+
 process.env["OPENAI_API_KEY"] = "mock_openai_key";
+
+const {
+  jsonCompletion,
+  proseCompletion,
+  subscribeOpenAILogging,
+} = await import("../src/index.ts");
 
 function proseCall(
   params: CompletionParams


### PR DESCRIPTION
## Summary
- stub the `node:timers/promises` timer in the Gemini unit tests before importing the implementation so exponential backoff retries resolve immediately
- apply the same timer override in the OpenAI tests to eliminate real delays while preserving the existing assertions

## Testing
- npm --workspace packages/gemini test
- npm --workspace packages/openai test

------
https://chatgpt.com/codex/tasks/task_e_68e59699826c83338767acdbd05b2f6b