### PR TITLE
Support simple SELECT projections in MockAzureContainer._query

### DIFF
--- a/packages/cosmosdb/src/mockAzureContainer.ts
+++ b/packages/cosmosdb/src/mockAzureContainer.ts
@@ -94,7 +94,9 @@ export class MockAzureContainer {
     if (projectedProperties) {
       return items.map((item) =>
         Object.fromEntries(
-          projectedProperties.map((property) => [property, item[property]]),
+          projectedProperties
+            .filter((property) => property in item)
+            .map((property) => [property, item[property]]),
         ),
       );
     }

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -176,7 +176,9 @@ describe("DB: Container", () => {
     "query: simple projection multiple properties",
     testSuccess(
       async (c) =>
-        c.query<Pick<Entry, "id" | "val">>("SELECT c.id, c.val, c._ts FROM c"),
+        c.query<Pick<Entry, "id" | "val">>(
+          "SELECT c.id, c.val, c._ts, c.notFound FROM c",
+        ),
       mockDB.map((item) => ({ id: item.id, val: item.val, _ts: item._ts })),
     ),
   );

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -11,12 +11,13 @@ interface Entry {
   id: string;
   pkey: string;
   val: number;
+  _ts: number;
 }
 
 const mockDB: Entry[] = [
-  { id: "1", pkey: "item", val: 123 },
-  { id: "2", pkey: "item", val: 456 },
-  { id: "3", pkey: "item", val: 789 },
+  { id: "1", pkey: "item", val: 123, _ts: 1234567890 },
+  { id: "2", pkey: "item", val: 456, _ts: 1234567891 },
+  { id: "3", pkey: "item", val: 789, _ts: 1234567892 },
 ];
 
 const connectOptions = {
@@ -172,11 +173,11 @@ describe("DB: Container", () => {
   );
 
   test(
-    "query: simple projection id and val",
+    "query: simple projection multiple properties",
     testSuccess(
       async (c) =>
-        c.query<Pick<Entry, "id" | "val">>("SELECT c.id, c.val FROM c"),
-      mockDB.map((item) => ({ id: item.id, val: item.val })),
+        c.query<Pick<Entry, "id" | "val">>("SELECT c.id, c.val, c._ts FROM c"),
+      mockDB.map((item) => ({ id: item.id, val: item.val, _ts: item._ts })),
     ),
   );
 
@@ -198,7 +199,8 @@ describe("DB: Container", () => {
   test(
     "upsertItem: success",
     testSuccess(
-      async (c) => c.upsertItem({ id: "1", pkey: "item", val: 999 }),
+      async (c) =>
+        c.upsertItem({ id: "1", pkey: "item", val: 999, _ts: 1234567899 }),
       undefined,
     ),
   );
@@ -206,7 +208,7 @@ describe("DB: Container", () => {
   test(
     "upsertItem: error",
     testError(async (c) =>
-      c.upsertItem({ id: "1", pkey: FORCE_ERROR, val: 500 }),
+      c.upsertItem({ id: "1", pkey: FORCE_ERROR, val: 500, _ts: 1234567899 }),
     ),
   );
 

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -172,6 +172,23 @@ describe("DB: Container", () => {
   );
 
   test(
+    "query: simple projection id and val",
+    testSuccess(
+      async (c) =>
+        c.query<Pick<Entry, "id" | "val">>("SELECT c.id, c.val FROM c"),
+      mockDB.map((item) => ({ id: item.id, val: item.val })),
+    ),
+  );
+
+  test(
+    "query: simple projection id only",
+    testSuccess(
+      async (c) => c.query<Pick<Entry, "id">>("SELECT c.id FROM c"),
+      mockDB.map((item) => ({ id: item.id })),
+    ),
+  );
+
+  test(
     "query: error",
     testError(async (c) =>
       c.query("SELECT * FROM c", { partitionKey: FORCE_ERROR }),


### PR DESCRIPTION
### Motivation
- The mock Cosmos container previously only special-cased `SELECT c.id FROM c`, causing projection queries that select other properties to return full items instead of only the selected fields. 
- Tests and consumers expect simple projection queries like `SELECT c.id, c.name FROM c` to return arrays of objects containing only the requested properties.

### Description
- Updated `MockAzureContainer._query` to detect simple projection-only queries and return objects with only the selected properties by using a new helper `getSimpleSelectedProperties`.
- Added `getSimpleSelectedProperties` which parses `SELECT c.<prop>[, c.<prop>...] FROM c` using a regex and rejects unsupported shapes (e.g. `*`, `VALUE`, aliases, or non-`c.<prop>` expressions) to retain existing behavior for complex queries.
- The projection mapping uses `Object.fromEntries` to construct result objects and preserves existing special-case for `SELECT VALUE COUNT(1) FROM c` and custom query matchers in `this.#queries`.
- Added tests in `packages/cosmosdb/test/container.test.ts` to validate both single-property and multi-property projection queries.

### Testing
- Ran `npm run pre-checkin` which executes linting, formatting, and the full test suite across workspaces, and the command completed successfully with all tests passing. 
- The `packages/cosmosdb` tests (including the new projection tests) passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3c99382483339cc2e1bec30536f0)