### PR TITLE
refactor(cosmosdb): separate mock fixture data from query handlers

### DIFF
--- a/packages/cosmosdb/README.md
+++ b/packages/cosmosdb/README.md
@@ -86,7 +86,7 @@ const results = await container.query(query.build(100));
 
 ### Mock Database (Testing)
 
-For tests, you can bypass Azure entirely by supplying `mockDBDataOptions` and optional `mockDBQueryOptions`.
+For tests, you can bypass Azure entirely by supplying `mockDBData` and optional `mockDBQueries`.
 
 ```typescript
 import { connectDB } from "dry-utils-cosmosdb";
@@ -96,31 +96,27 @@ const db = await connectDB({
   key: "unused-for-mock",
   name: "unused-for-mock",
   containers: [{ name: "users", partitionKey: "userId" }],
-  mockDBDataOptions: {
-    users: {
-      data: [
-        { id: "1", userId: "u-1", status: "active" },
-        { id: "2", userId: "u-2", status: "inactive" },
-      ],
-    },
+  mockDBData: {
+    users: [
+      { id: "1", userId: "u-1", status: "active" },
+      { id: "2", userId: "u-2", status: "inactive" },
+    ],
   },
-  mockDBQueryOptions: {
-    users: {
-      queries: [
-        {
-          matcher: /WHERE c\.status = @status/,
-          func: (items, getParam) => {
-            const status = getParam<string>("@status");
-            return items.filter((item) => item.status === status);
-          },
+  mockDBQueries: {
+    users: [
+      {
+        matcher: /WHERE c\.status = @status/,
+        func: (items, getParam) => {
+          const status = getParam<string>("@status");
+          return items.filter((item) => item.status === status);
         },
-      ],
-    },
+      },
+    ],
   },
 });
 ```
 
-The `queries` matchers let you intercept query text and return custom results from fixture data.
+The `mockDBQueries` matchers let you intercept query text and return custom results from fixture data.
 
 ### CRUD Operations
 

--- a/packages/cosmosdb/README.md
+++ b/packages/cosmosdb/README.md
@@ -86,7 +86,7 @@ const results = await container.query(query.build(100));
 
 ### Mock Database (Testing)
 
-For tests, you can bypass Azure entirely by supplying `mockDBOptions`.
+For tests, you can bypass Azure entirely by supplying `mockDBDataOptions` and optional `mockDBQueryOptions`.
 
 ```typescript
 import { connectDB } from "dry-utils-cosmosdb";
@@ -96,12 +96,16 @@ const db = await connectDB({
   key: "unused-for-mock",
   name: "unused-for-mock",
   containers: [{ name: "users", partitionKey: "userId" }],
-  mockDBOptions: {
+  mockDBDataOptions: {
     users: {
       data: [
         { id: "1", userId: "u-1", status: "active" },
         { id: "2", userId: "u-2", status: "inactive" },
       ],
+    },
+  },
+  mockDBQueryOptions: {
+    users: {
       queries: [
         {
           matcher: /WHERE c\.status = @status/,

--- a/packages/cosmosdb/src/index.ts
+++ b/packages/cosmosdb/src/index.ts
@@ -2,5 +2,6 @@ import { Container } from "./container.ts";
 import { connectDB } from "./dbInit.ts";
 
 export { subscribeCosmosDBLogging } from "./diagnostics.ts";
+export type { MockQueryDef } from "./mockAzureContainer.ts";
 export { Query } from "./Query.ts";
 export { connectDB, Container };

--- a/packages/cosmosdb/src/mockAzureContainer.ts
+++ b/packages/cosmosdb/src/mockAzureContainer.ts
@@ -16,8 +16,11 @@ interface QueryDef {
   ) => unknown[];
 }
 
-export interface MockAzureContainerOptions {
+export interface MockAzureContainerDataOptions {
   data?: Item[];
+}
+
+export interface MockAzureContainerQueryOptions {
   queries?: QueryDef[];
 }
 
@@ -29,7 +32,8 @@ export class MockAzureContainer {
 
   constructor(
     pkey: string,
-    { data = [], queries = [] }: MockAzureContainerOptions = {},
+    { data = [] }: MockAzureContainerDataOptions = {},
+    { queries = [] }: MockAzureContainerQueryOptions = {},
   ) {
     this.#pkey = pkey;
     this.#queries = queries;

--- a/packages/cosmosdb/src/mockAzureContainer.ts
+++ b/packages/cosmosdb/src/mockAzureContainer.ts
@@ -8,7 +8,7 @@ import type {
 
 const FORCE_ERROR = "FORCE_ERROR";
 
-interface QueryDef {
+export interface MockQueryDef {
   matcher: string | RegExp;
   func: (
     items: Item[],
@@ -16,25 +16,13 @@ interface QueryDef {
   ) => unknown[];
 }
 
-export interface MockAzureContainerDataOptions {
-  data?: Item[];
-}
-
-export interface MockAzureContainerQueryOptions {
-  queries?: QueryDef[];
-}
-
 export class MockAzureContainer {
   // Data structure: { pkey: { id: item } }
   readonly #data: Record<string, Record<string, Item>> = {};
   readonly #pkey: string;
-  readonly #queries: QueryDef[] = [];
+  readonly #queries: MockQueryDef[] = [];
 
-  constructor(
-    pkey: string,
-    { data = [] }: MockAzureContainerDataOptions = {},
-    { queries = [] }: MockAzureContainerQueryOptions = {},
-  ) {
+  constructor(pkey: string, data: Item[] = [], queries: MockQueryDef[] = []) {
     this.#pkey = pkey;
     this.#queries = queries;
     data.forEach((item) => this._addItem(item));

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -29,9 +29,13 @@ const connectOptions = {
 async function getContainer() {
   const containerMap = await connectDB({
     ...connectOptions,
-    mockDBOptions: {
+    mockDBDataOptions: {
       mockContainer: {
         data: structuredClone(mockDB),
+      },
+    },
+    mockDBQueryOptions: {
+      mockContainer: {
         queries: [
           {
             matcher: "SELECT * FROM c WHERE c.val > @minValue",

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -29,23 +29,19 @@ const connectOptions = {
 async function getContainer() {
   const containerMap = await connectDB({
     ...connectOptions,
-    mockDBDataOptions: {
-      mockContainer: {
-        data: structuredClone(mockDB),
-      },
+    mockDBData: {
+      mockContainer: structuredClone(mockDB),
     },
-    mockDBQueryOptions: {
-      mockContainer: {
-        queries: [
-          {
-            matcher: "SELECT * FROM c WHERE c.val > @minValue",
-            func: (items, getParam) => {
-              const minValue = getParam<number>("@minValue") ?? 400;
-              return items.filter((item) => item["val"] > minValue);
-            },
+    mockDBQueries: {
+      mockContainer: [
+        {
+          matcher: "SELECT * FROM c WHERE c.val > @minValue",
+          func: (items, getParam) => {
+            const minValue = getParam<number>("@minValue") ?? 400;
+            return items.filter((item) => item["val"] > minValue);
           },
-        ],
-      },
+        },
+      ],
     },
   });
   return containerMap["mockContainer"] as Container<Entry>;

--- a/packages/cosmosdb/test/dbInit.test.ts
+++ b/packages/cosmosdb/test/dbInit.test.ts
@@ -139,14 +139,12 @@ describe("DB: DBInit", () => {
     const options = {
       ...connectOptions,
       containers: [{ name: "id", partitionKey: "pkey" }],
-      mockDBDataOptions: {
-        id: {
-          data: [
-            { id: "item1", pkey: "p1", value: "test1" },
-            { id: "item2", pkey: "p1", value: "test2" },
-            { id: "item3", pkey: "p2", value: "test3" },
-          ],
-        },
+      mockDBData: {
+        id: [
+          { id: "item1", pkey: "p1", value: "test1" },
+          { id: "item2", pkey: "p1", value: "test2" },
+          { id: "item3", pkey: "p2", value: "test3" },
+        ],
       },
     };
 

--- a/packages/cosmosdb/test/dbInit.test.ts
+++ b/packages/cosmosdb/test/dbInit.test.ts
@@ -139,7 +139,7 @@ describe("DB: DBInit", () => {
     const options = {
       ...connectOptions,
       containers: [{ name: "id", partitionKey: "pkey" }],
-      mockDBOptions: {
+      mockDBDataOptions: {
         id: {
           data: [
             { id: "item1", pkey: "p1", value: "test1" },


### PR DESCRIPTION
### Motivation

- Keep mutable, caller-specific fixture data separate from static query handler logic for clearer APIs and easier test configuration.
- Avoid bundling .env-driven or frequently changing mock data with the library's static query definitions.

### Description

- Split the combined mock option type into `MockAzureContainerDataOptions` (holds `data`) and `MockAzureContainerQueryOptions` (holds `queries`) in `packages/cosmosdb/src/mockAzureContainer.ts` and updated the `MockAzureContainer` constructor to accept data and query options separately.
- Updated `connectDB` and `connectMockDB` in `packages/cosmosdb/src/dbInit.ts` to accept `mockDBDataOptions` and `mockDBQueryOptions` and to instantiate `MockAzureContainer` with the two separate option objects.
- Updated tests in `packages/cosmosdb/test/container.test.ts` and `packages/cosmosdb/test/dbInit.test.ts` to use `mockDBDataOptions` and `mockDBQueryOptions` respectively.
- Updated the README example in `packages/cosmosdb/README.md` to document the new `mockDBDataOptions` / `mockDBQueryOptions` configuration.

### Testing

- Ran `npm run pre-checkin` (which runs lint, `format:write`, and tests) across the monorepo and it completed successfully.
- The workspace test suites were executed and all tests passed for the updated `cosmosdb` package and other workspace packages (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3bd19a2c8333ba8fd3c57a69c53e)