### PR TITLE
Publish: CosmosDB functionality improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -832,9 +832,10 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
-      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.3.0.tgz",
+      "integrity": "sha512-rXDhXUBj31gZafcwQFbXvt8jMrMxZoK7ECjQpk88UfA/OkZls3PtZDprT9lM3jjqRtwRjQoNLoPoNq6MlV8qLw==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -3147,7 +3148,7 @@
       "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "^1.11.0",
+        "@google/genai": "^2.3.0",
         "zod": "^4.1.3"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -500,9 +500,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -568,9 +568,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -687,9 +687,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1009,9 +1009,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1023,9 +1023,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1068,17 +1068,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1091,7 +1091,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1107,16 +1107,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1132,14 +1132,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1154,14 +1154,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1189,15 +1189,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1228,16 +1228,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1256,16 +1256,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1280,13 +1280,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1406,9 +1406,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1502,6 +1502,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1655,9 +1661,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1668,32 +1674,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1709,16 +1715,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
@@ -2045,19 +2051,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2302,6 +2295,15 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2378,9 +2380,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -2450,9 +2452,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
-      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "version": "6.38.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
+      "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -2579,9 +2581,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2639,9 +2641,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2686,16 +2688,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -2735,15 +2727,16 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }
@@ -2757,9 +2750,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2887,14 +2880,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2947,16 +2939,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
-      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.1",
-        "@typescript-eslint/parser": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3064,9 +3056,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3098,9 +3090,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3117,7 +3117,7 @@
     },
     "packages/cosmosdb": {
       "name": "dry-utils-cosmosdb",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^4.2.0"
@@ -3137,7 +3137,7 @@
     },
     "packages/gemini": {
       "name": "dry-utils-gemini",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^2.3.0",

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier . --write",
-    "test": "node --import tsx/esm --test --test-reporter=dot test/**/*.test.ts",
-    "test-details": "node --import tsx/esm --test test/**/*.test.ts",
+    "test": "node --import tsx --test --test-reporter=dot test/**/*.test.ts",
+    "test-details": "node --import tsx --test test/**/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "link": "npm link",
     "unlink": "npm unlink --global",

--- a/packages/cosmosdb/README.md
+++ b/packages/cosmosdb/README.md
@@ -78,11 +78,12 @@ Build SQL queries with best practices for performance:
 ```typescript
 import { Query } from "dry-utils-cosmosdb";
 
-// Create a query to find active premium users
+// Create a query to find active/pending premium users, sorted by most recent first
 const query = new Query()
-  .whereCondition("status", "=", "active")
+  .whereCondition("status", "IN", ["active", "pending"])
   .whereCondition("userType", "=", "premium")
-  .whereCondition("createdDate", ">", "2023-01-01");
+  .whereCondition("createdDate", ">", "2023-01-01")
+  .orderBy("_ts", "DESC");
 
 // Execute the query
 const results = await container.query(query.top(100).build());
@@ -122,6 +123,27 @@ const db = await connectDB({
 
 The `mockDBFilters` matchers let you intercept WHERE clauses and return custom filtered results from fixture data. Use `mockDBProjects` the same way to intercept SELECT projections.
 
+### Loading Mock Data from JSON
+
+Use `loadMockDBData` to load mock data from an inline JSON string or a file path, rather than hard-coding it inline:
+
+```typescript
+import { connectDB, loadMockDBData } from "dry-utils-cosmosdb";
+
+const db = await connectDB({
+  endpoint: "unused-for-mock",
+  key: "unused-for-mock",
+  name: "unused-for-mock",
+  containers: [{ name: "users", partitionKey: "userId" }],
+  mockDBData: loadMockDBData({
+    mockDataPath: "/path/to/fixtures.json", // JSON file keyed by container name
+    mockDataJson: '{"users":[{"id":"override","userId":"u-0"}]}', // inline overrides
+  }),
+});
+```
+
+When both sources are supplied, inline JSON takes precedence for any duplicate container keys.
+
 ### CRUD Operations
 
 Perform common database operations:
@@ -130,13 +152,14 @@ Perform common database operations:
 // Get an item by ID
 const user = await container.getItem("user123", "partition1");
 
-// Create or update an item
-await container.upsertItem({
+// Create or update an item - returns the item as stored, including system properties
+const stored = await container.upsertItem({
   id: "user123",
   userId: "partition1",
   name: "John Doe",
   email: "john@example.com",
 });
+console.log(stored._ts); // timestamp assigned by CosmosDB
 
 // Delete an item
 await container.deleteItem("user123", "partition1");
@@ -146,7 +169,17 @@ const activeUsers = await container.query({
   query: "SELECT * FROM c WHERE c.status = @status",
   parameters: [{ name: "@status", value: "active" }],
 });
+
+// Count items, optionally scoped to a partition
+const total = await container.getCount();
+const partitionCount = await container.getCount(undefined, "partition1");
+
+// Count items bucketed by a property value (supports dot-path notation)
+const byStatus = await container.getCountBy("status");
+const byRegion = await container.getCountBy("location.regionCode");
 ```
+
+Item IDs are validated before use. IDs that are empty, contain `/`, `\`, or `#`, or exceed 1,023 bytes will throw immediately rather than failing at the service layer.
 
 ### Subscribing to Logging Events
 

--- a/packages/cosmosdb/README.md
+++ b/packages/cosmosdb/README.md
@@ -179,7 +179,7 @@ const byStatus = await container.getCountBy("status");
 const byRegion = await container.getCountBy("location.regionCode");
 ```
 
-Item IDs are validated before use. IDs that are empty, contain `/`, `\`, or `#`, or exceed 1,023 bytes will throw immediately rather than failing at the service layer.
+Item IDs are validated before use. IDs that are empty, contain `/`, `\`, `#`, `?`, or `%`, or exceed 1,023 bytes will throw immediately rather than failing at the service layer.
 
 ### Subscribing to Logging Events
 

--- a/packages/cosmosdb/e2e/cosmos.test.ts
+++ b/packages/cosmosdb/e2e/cosmos.test.ts
@@ -23,6 +23,7 @@ export interface Model {
 }
 
 const id = "test-item-1";
+const id2 = "test-item-2";
 const dbActionLog = { agg: 1 };
 
 describe("CosmosDB E2E Flow", () => {
@@ -82,10 +83,15 @@ describe("CosmosDB E2E Flow", () => {
   test("upsertItem", async () => {
     assert.ok(container, "Container should be defined");
 
-    const testItem: Model = { id };
-    await container.upsertItem(testItem);
+    const result1 = await container.upsertItem({ id });
+    assert.equal(result1.id, id, "Returned item should have correct ID");
+    assert.ok(result1._ts, "Returned item should have _ts system property");
 
-    logCounts(dbActionLog, "upsertItem");
+    const result2 = await container.upsertItem({ id: id2 });
+    assert.equal(result2.id, id2, "Returned item should have correct ID");
+    assert.ok(result2._ts, "Returned item should have _ts system property");
+
+    logCounts({ agg: 2 }, "upsertItem");
   });
 
   test("getItem", async () => {
@@ -134,9 +140,11 @@ describe("CosmosDB E2E Flow", () => {
     assert.ok(container, "Container should be defined");
 
     const count = await container.getCount();
-
-    assert.equal(count, 1, "Should have 1 item in the container");
+    assert.equal(count, 2, "Should have 2 items in the container");
     logCounts(dbActionLog, "getCount");
+
+    const partitionCount = await container.getCount(undefined, id);
+    assert.equal(partitionCount, 1, "Should have 1 item in the partition");
   });
 
   test("query", async () => {
@@ -151,11 +159,42 @@ describe("CosmosDB E2E Flow", () => {
     logCounts(dbActionLog, "query");
   });
 
+  test("query: IN operator", async () => {
+    assert.ok(container, "Container should be defined");
+
+    const results = await container.query<Model>(
+      new Query().whereCondition("id", "IN", [id, id2]),
+    );
+
+    assert.equal(results.length, 2, "IN query should find both items");
+    const ids = results.map((r) => r.id).sort();
+    assert.deepEqual(ids, [id, id2], "IN query should return correct IDs");
+    logCounts(dbActionLog, "query: IN");
+  });
+
+  test("query: orderBy", async () => {
+    assert.ok(container, "Container should be defined");
+
+    const asc = await container.query<Model>(new Query().orderBy("id"));
+    assert.equal(asc.length, 2, "orderBy ASC should return all items");
+    assert.equal(asc[0]?.id, id, "First item ASC should be test-item-1");
+    assert.equal(asc[1]?.id, id2, "Second item ASC should be test-item-2");
+    logCounts(dbActionLog, "query: orderBy ASC");
+
+    const desc = await container.query<Model>(
+      new Query().orderBy("id", "DESC"),
+    );
+    assert.equal(desc.length, 2, "orderBy DESC should return all items");
+    assert.equal(desc[0]?.id, id2, "First item DESC should be test-item-2");
+    assert.equal(desc[1]?.id, id, "Second item DESC should be test-item-1");
+  });
+
   test("deleteItem", async () => {
     assert.ok(container, "Container should be defined");
 
     await container.deleteItem(id, id);
+    await container.deleteItem(id2, id2);
 
-    logCounts(dbActionLog, "deleteItem");
+    logCounts({ agg: 2 }, "deleteItem");
   });
 });

--- a/packages/cosmosdb/package.json
+++ b/packages/cosmosdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dry-utils-cosmosdb",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Personal, hyper-specific collection of CosmosDB abstractions",
   "type": "module",
   "sideEffects": false,

--- a/packages/cosmosdb/package.json
+++ b/packages/cosmosdb/package.json
@@ -33,9 +33,9 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier . --write",
-    "test": "node --import tsx/esm --test --test-reporter=dot test/**/*.test.ts",
-    "test-details": "node --import tsx/esm --test test/**/*.test.ts",
-    "e2e": "node --import tsx/esm --test e2e/**/*.test.ts",
+    "test": "node --import tsx --test --test-reporter=dot test/**/*.test.ts",
+    "test-details": "node --import tsx --test test/**/*.test.ts",
+    "e2e": "node --import tsx --test e2e/**/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "link": "npm link",
     "unlink": "npm unlink --global",

--- a/packages/cosmosdb/src/Query.ts
+++ b/packages/cosmosdb/src/Query.ts
@@ -1,6 +1,6 @@
 import type { JSONValue, SqlQuerySpec } from "@azure/cosmos";
 
-type Op = "<" | "<=" | "=" | ">" | ">=" | "CONTAINS";
+type Op = "<" | "<=" | "=" | ">" | ">=" | "CONTAINS" | "IN";
 type Selector = "*" | "ID" | "COUNT";
 
 export type Condition = [field: string, op: Op, value: JSONValue];
@@ -59,6 +59,7 @@ export class Query {
   #selector: Selector;
   #top?: number;
   #whereClauses: string[] = [];
+  #orderClauses: string[] = [];
   #params: Record<string, JSONValue> = {};
 
   constructor(selector?: Selector, condition?: Condition) {
@@ -92,6 +93,17 @@ export class Query {
   }
 
   /**
+   * Adds an ORDER BY clause to the query.
+   * @param field Document field path (e.g., `"_ts"` or `"facets.score"`)
+   * @param direction Sort direction, defaults to `"ASC"`
+   * @returns The Query instance for method chaining
+   */
+  orderBy(field: string, direction: "ASC" | "DESC" = "ASC"): this {
+    this.#orderClauses.push(`c.${field} ${direction}`);
+    return this;
+  }
+
+  /**
    * Adds a WHERE clause to the query.
    * @param clause The WHERE clause to add
    * @param parameters Optional parameters for the clause
@@ -121,9 +133,12 @@ export class Query {
    */
   build(): SqlQuerySpec {
     const top = this.#top != null ? ` TOP ${this.#top}` : "";
+    const order = this.#orderClauses.length
+      ? ` ORDER BY ${this.#orderClauses.join(", ")}`
+      : "";
 
     return {
-      query: `SELECT${top} ${this.#getSelectorString()} FROM c${this.#getWhereString()}`,
+      query: `SELECT${top} ${this.#getSelectorString()} FROM c${this.#getWhereString()}${order}`,
       parameters: Object.entries(this.#params).map(([name, value]) => ({
         name,
         value,
@@ -158,6 +173,15 @@ export class Query {
    */
   static condition(...[field, op, value]: Condition): Where {
     const [prop, param] = toPair(field);
+
+    if (op === "IN") {
+      if (!Array.isArray(value) || !value.length) {
+        throw new Error("IN operator requires a non-empty array of values");
+      }
+      const pairs = value.map((v, i) => [`${param}_${i}`, v] as const);
+      const paramList = pairs.map(([p]) => p).join(", ");
+      return [`${prop} IN (${paramList})`, Object.fromEntries(pairs)];
+    }
 
     if (op === "CONTAINS") {
       return [`CONTAINS(${prop}, ${param}, true)`, { [param]: value }];

--- a/packages/cosmosdb/src/Query.ts
+++ b/packages/cosmosdb/src/Query.ts
@@ -1,4 +1,5 @@
 import type { JSONValue, SqlQuerySpec } from "@azure/cosmos";
+import { validatePropPath } from "./utils.ts";
 
 type Op = "<" | "<=" | "=" | ">" | ">=" | "CONTAINS" | "IN";
 type Selector = "*" | "ID" | "COUNT";
@@ -99,6 +100,7 @@ export class Query {
    * @returns The Query instance for method chaining
    */
   orderBy(field: string, direction: "ASC" | "DESC" = "ASC"): this {
+    validatePropPath(field);
     this.#orderClauses.push(`c.${field} ${direction}`);
     return this;
   }
@@ -172,6 +174,7 @@ export class Query {
    * @returns WHERE clause and its parameters
    */
   static condition(...[field, op, value]: Condition): Where {
+    validatePropPath(field);
     const [prop, param] = toPair(field);
 
     if (op === "IN") {

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -18,6 +18,34 @@ interface CountBy {
 
 const validProp = new RegExp(/^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$/);
 
+/** Maximum byte length for a Cosmos DB item ID. */
+const MAX_ID_BYTES = 1023;
+
+/**
+ * Validates that a Cosmos DB item ID is safe to use.
+ * Throws if the ID is empty, contains forbidden characters (`/`, `\`, `#`),
+ * or exceeds 1,023 bytes.
+ *
+ * Forbidden characters: `/` and `\` are rejected by the service; `#` is
+ * treated as a URL fragment delimiter by HTTP infrastructure and must not
+ * appear in IDs used in REST paths.
+ */
+function validateItemId(id: string): void {
+  if (!id) {
+    throw new Error("Item ID must not be empty.");
+  }
+  if (/[/\\#]/.test(id)) {
+    throw new Error(
+      `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+    );
+  }
+  if (Buffer.byteLength(id, "utf8") > MAX_ID_BYTES) {
+    throw new Error(
+      `Item ID exceeds the maximum allowed length of ${MAX_ID_BYTES} bytes.`,
+    );
+  }
+}
+
 /**
  * Generic container class for database operations
  * @template Item The type of items stored in the container
@@ -41,6 +69,7 @@ export class Container<Item extends ItemDefinition> {
     id: string,
     partitionKey: string,
   ): Promise<(Item & Resource) | undefined> {
+    validateItemId(id);
     try {
       const response = await this.container.item(id, partitionKey).read<Item>();
       logDBAction("READ", this.name, response, partitionKey);
@@ -147,6 +176,9 @@ export class Container<Item extends ItemDefinition> {
    * @returns The item as stored, including system properties (`_ts`, `_etag`, etc.)
    */
   async upsertItem(item: Item): Promise<Item & Resource> {
+    if (item.id !== undefined) {
+      validateItemId(item.id);
+    }
     try {
       const response = await this.container.items.upsert(item);
       logDBAction("UPSERT", this.name, response);
@@ -163,6 +195,7 @@ export class Container<Item extends ItemDefinition> {
    * @param partitionKey The partition key for the item
    */
   async deleteItem(id: string, partitionKey: string): Promise<void> {
+    validateItemId(id);
     try {
       const response = await this.container.item(id, partitionKey).delete();
       logDBAction("DELETE", this.name, response, partitionKey);

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -10,13 +10,12 @@ import type {
 } from "@azure/cosmos";
 import { diag } from "./diagnostics.ts";
 import { Query, type Condition } from "./Query.ts";
+import { validatePropPath } from "./utils.ts";
 
 interface CountBy {
   name: unknown;
   count: number;
 }
-
-const validProp = new RegExp(/^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$/);
 
 /** Maximum byte length for a Cosmos DB item ID. */
 const MAX_ID_BYTES = 1023;
@@ -135,9 +134,7 @@ export class Container<Item extends ItemDefinition> {
    * @returns Array of `{ name, count }` pairs, one per distinct value
    */
   async getCountBy(prop: string): Promise<CountBy[]> {
-    if (!validProp.test(prop)) {
-      throw new Error(`Invalid property "${prop}". Only 'A-Za-z0-9_' allowed.`);
-    }
+    validatePropPath(prop);
 
     return this.query<CountBy>(
       `SELECT c.${prop} AS name, COUNT(1) AS count FROM c WHERE IS_DEFINED(c.${prop}) GROUP BY c.${prop}`,

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -86,11 +86,11 @@ export class Container<Item extends ItemDefinition> {
   /**
    * Gets the count of items in the container
    * @param condition Optional condition to filter the items
-   * @returns The number of items matching the condition
+   * @returns The count of items matching the condition, or 0 if none
    */
-  async getCount(condition?: Condition): Promise<number | undefined> {
+  async getCount(condition?: Condition): Promise<number> {
     const response = await this.query<number>(new Query("COUNT", condition));
-    return response[0];
+    return response[0] ?? 0;
   }
 
   /**

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -22,20 +22,21 @@ const MAX_ID_BYTES = 1023;
 
 /**
  * Validates that a Cosmos DB item ID is safe to use.
- * Throws if the ID is empty, contains forbidden characters (`/`, `\`, `#`),
+ * Throws if the ID is empty, contains forbidden characters (`/`, `\`, `#`, `?`, `%`),
  * or exceeds 1,023 bytes.
  *
  * Forbidden characters: `/` and `\` are rejected by the service; `#` is
- * treated as a URL fragment delimiter by HTTP infrastructure and must not
- * appear in IDs used in REST paths.
+ * treated as a URL fragment delimiter by HTTP infrastructure; `?` introduces
+ * query strings; `%` is used for percent-encoding. None of these are allowed
+ * in IDs used in REST paths.
  */
 function validateItemId(id: string): void {
   if (!id) {
     throw new Error("Item ID must not be empty.");
   }
-  if (/[/\\#]/.test(id)) {
+  if (/[/\\#?%]/.test(id)) {
     throw new Error(
-      `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+      `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
     );
   }
   if (Buffer.byteLength(id, "utf8") > MAX_ID_BYTES) {

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -86,10 +86,17 @@ export class Container<Item extends ItemDefinition> {
   /**
    * Gets the count of items in the container
    * @param condition Optional condition to filter the items
+   * @param partitionKey Optional partition key to scope the count to a single partition
    * @returns The count of items matching the condition, or 0 if none
    */
-  async getCount(condition?: Condition): Promise<number> {
-    const response = await this.query<number>(new Query("COUNT", condition));
+  async getCount(
+    condition?: Condition,
+    partitionKey?: string,
+  ): Promise<number> {
+    const response = await this.query<number>(
+      new Query("COUNT", condition),
+      partitionKey ? { partitionKey } : undefined,
+    );
     return response[0] ?? 0;
   }
 
@@ -137,11 +144,13 @@ export class Container<Item extends ItemDefinition> {
   /**
    * Creates or updates an item in the container
    * @param item The item to upsert
+   * @returns The item as stored, including system properties (`_ts`, `_etag`, etc.)
    */
-  async upsertItem(item: Item): Promise<void> {
+  async upsertItem(item: Item): Promise<Item & Resource> {
     try {
       const response = await this.container.items.upsert(item);
       logDBAction("UPSERT", this.name, response);
+      return response.resource as Item & Resource;
     } catch (error) {
       diag.error("UpsertItem", error);
       throw error;

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -16,7 +16,7 @@ interface CountBy {
   count: number;
 }
 
-const validProp = new RegExp(/^[A-Za-z0-9_]+$/);
+const validProp = new RegExp(/^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$/);
 
 /**
  * Generic container class for database operations
@@ -95,10 +95,10 @@ export class Container<Item extends ItemDefinition> {
 
   /**
    * Gets the count of items bucketed by the distinct values of a property
-   * @param prop The property name to group by, 'A-Za-z0-9_' only
+   * @param prop The property path to group by (e.g. `"status"` or `"location.regionCode"`). Only `A-Za-z0-9_` identifiers separated by `.` are allowed.
    * @returns Array of `{ name, count }` pairs, one per distinct value
    */
-  async getCountBy(prop: keyof Item & string): Promise<CountBy[]> {
+  async getCountBy(prop: string): Promise<CountBy[]> {
     if (!validProp.test(prop)) {
       throw new Error(`Invalid property "${prop}". Only 'A-Za-z0-9_' allowed.`);
     }

--- a/packages/cosmosdb/src/index.ts
+++ b/packages/cosmosdb/src/index.ts
@@ -6,5 +6,6 @@ export {
   type MockDBQueryDefs,
 } from "./dbInit.ts";
 export { subscribeCosmosDBLogging } from "./diagnostics.ts";
+export { loadMockDBData, type MockDBDataOptions } from "./mockDbData.ts";
 export type { MockQueryDef } from "./mockQueryProcessor.ts";
 export { Query } from "./Query.ts";

--- a/packages/cosmosdb/src/mockDbData.ts
+++ b/packages/cosmosdb/src/mockDbData.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import type { MockDBData } from "./dbInit.ts";
+
+export interface MockDBDataOptions {
+  /** Inline JSON string containing mock data, keyed by container name. */
+  mockDataJson?: string;
+  /** Absolute path to a JSON file containing mock data, keyed by container name. */
+  mockDataPath?: string;
+}
+
+/**
+ * Loads Cosmos DB mock data from JSON sources.
+ * Inline JSON overrides duplicate container keys loaded from the file source.
+ * @param options Optional sources for mock data: inline JSON and/or a file path.
+ * @returns Parsed mock data map, or undefined when no sources are configured.
+ */
+export function loadMockDBData({
+  mockDataJson,
+  mockDataPath,
+}: MockDBDataOptions): MockDBData | undefined {
+  const trimJson = mockDataJson?.trim();
+  const trimPath = mockDataPath?.trim();
+
+  if (!trimJson && !trimPath) {
+    return undefined;
+  }
+
+  const fileData = trimPath
+    ? parseMockDBData(fs.readFileSync(trimPath, "utf-8"), `file ${trimPath}`)
+    : undefined;
+
+  const inlineData = trimJson
+    ? parseMockDBData(trimJson, "mockDataJson")
+    : undefined;
+
+  return {
+    ...(fileData ?? {}),
+    ...(inlineData ?? {}),
+  };
+}
+
+function parseMockDBData(rawJson: string, source: string): MockDBData {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch (error) {
+    throw new Error(`Invalid Cosmos DB mock data JSON in ${source}.`, {
+      cause: error,
+    });
+  }
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(
+      `Cosmos DB mock data in ${source} must be a JSON object keyed by container name.`,
+    );
+  }
+
+  return parsed as MockDBData;
+}

--- a/packages/cosmosdb/src/mockDbData.ts
+++ b/packages/cosmosdb/src/mockDbData.ts
@@ -17,7 +17,7 @@ export interface MockDBDataOptions {
 export function loadMockDBData({
   mockDataJson,
   mockDataPath,
-}: MockDBDataOptions): MockDBData | undefined {
+}: MockDBDataOptions = {}): MockDBData | undefined {
   const trimJson = mockDataJson?.trim();
   const trimPath = mockDataPath?.trim();
 

--- a/packages/cosmosdb/src/mockQueryProcessor.ts
+++ b/packages/cosmosdb/src/mockQueryProcessor.ts
@@ -4,9 +4,9 @@ import type {
   SqlQuerySpec,
 } from "@azure/cosmos";
 
-// Split into SELECT, FROM, WHERE components, supporting optional TOP and GROUP BY (ignored in processing but allows matching queries from Container and Query.build()).
+// Split into SELECT, FROM, WHERE, ORDER BY components, supporting optional TOP and GROUP BY (ignored in processing but allows matching queries from Container and Query.build()).
 const querySplitter = new RegExp(
-  /^\s*SELECT\s+(?:TOP\s+(?<top>\d+)\s+)?(?<select>.+?)\s+FROM\s+c(?:\s+WHERE\s+(?<where>.+?))?(?:\s+GROUP\s+BY\s+.+)?\s*$/i,
+  /^\s*SELECT\s+(?:TOP\s+(?<top>\d+)\s+)?(?<select>.+?)\s+FROM\s+c(?:\s+WHERE\s+(?<where>.+?))?(?:\s+ORDER\s+BY\s+(?<orderby>.+?))?(?:\s+GROUP\s+BY\s+.+)?\s*$/i,
 );
 const cond_is_defined = new RegExp(
   /^IS_DEFINED\(c\.(?<field>[A-Za-z0-9_.]+)\)$/i,
@@ -16,6 +16,9 @@ const cond_contains = new RegExp(
 );
 const cond_compare = new RegExp(
   /^c\.(?<field>[A-Za-z0-9_.]+)\s*(?<op><=|>=|<|>|=)\s*(?<param>@[A-Za-z0-9_]+)$/i,
+);
+const cond_in = new RegExp(
+  /^c\.(?<field>[A-Za-z0-9_.]+)\s+IN\s+\((?<params>(?:@[A-Za-z0-9_]+)(?:\s*,\s*@[A-Za-z0-9_]+)*)\)$/i,
 );
 
 /**
@@ -114,7 +117,7 @@ export function processQuery(
   projects: MockQueryDef[] = [],
 ): unknown[] {
   const match = query.match(querySplitter)?.groups;
-  const { select, top, where } = match ?? {};
+  const { select, top, where, orderby } = match ?? {};
 
   if (!match || !select) {
     throw new Error(`Query did not match supported mocking pattern: ${query}`);
@@ -127,6 +130,10 @@ export function processQuery(
     ...filters,
     ...builtInFilters,
   ]) as Item[];
+
+  if (orderby) {
+    items = sortByOrderBy(items, orderby);
+  }
 
   const result = invokeMatchingDef({ items, params }, select, [
     ...projects,
@@ -157,6 +164,38 @@ function invokeMatchingDef(
   }
 
   return args.items;
+}
+
+/**
+ * Sorts items by a CosmosDB ORDER BY clause string.
+ * Parses `c.field [ASC|DESC], c.other [ASC|DESC]` and applies a stable multi-key sort.
+ */
+function sortByOrderBy(items: Item[], orderby: string): Item[] {
+  const parts = orderby.split(",").map((s) => {
+    const match = s
+      .trim()
+      .match(/^c\.(?<field>[A-Za-z0-9_.]+)(?:\s+(?<dir>ASC|DESC))?$/i);
+    return match
+      ? {
+          field: match.groups!["field"]!,
+          desc: match.groups!["dir"]?.toUpperCase() === "DESC",
+        }
+      : null;
+  });
+
+  return [...items].sort((a, b) => {
+    for (const part of parts) {
+      if (!part) continue;
+      const av = getFieldValue(a, part.field);
+      const bv = getFieldValue(b, part.field);
+      if (av === bv) continue;
+      if (av == null) return part.desc ? -1 : 1;
+      if (bv == null) return part.desc ? 1 : -1;
+      const cmp = av < bv ? -1 : 1;
+      return part.desc ? -cmp : cmp;
+    }
+    return 0;
+  });
 }
 
 /**
@@ -218,6 +257,14 @@ function evaluateCondition(
       case ">=":
         return itemValue >= paramValue;
     }
+  }
+
+  const inMatch = condition.match(cond_in);
+  if (inMatch) {
+    const { field, params: paramsStr } = inMatch.groups!;
+    const itemValue = getFieldValue(item, field!);
+    const values = paramsStr!.split(",").map((p) => params[p.trim()]);
+    return values.includes(itemValue as JSONValue);
   }
 
   throw new Error(`Unsupported WHERE condition in mock: ${condition}`);

--- a/packages/cosmosdb/src/utils.ts
+++ b/packages/cosmosdb/src/utils.ts
@@ -1,0 +1,14 @@
+const validProp = /^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$/;
+
+/**
+ * Validates that a Cosmos DB property path is safe to interpolate into SQL.
+ * Throws if the path contains anything other than `A-Za-z0-9_` identifiers
+ * separated by `.`.
+ */
+export function validatePropPath(value: string): void {
+  if (!validProp.test(value)) {
+    throw new Error(
+      `Invalid property path "${value}". Only A-Za-z0-9_ identifiers separated by '.' are allowed.`,
+    );
+  }
+}

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -454,4 +454,44 @@ describe("DB: Container", () => {
     "deleteItem: error",
     testError(async (c) => c.deleteItem("1", FORCE_ERROR)),
   );
+
+  test("getItem: rejects empty ID", async () => {
+    const c = await getContainer();
+    await assert.rejects(c.getItem("", "item"), {
+      message: "Item ID must not be empty.",
+    });
+  });
+
+  test("getItem: rejects IDs with forbidden characters", async () => {
+    const c = await getContainer();
+    for (const id of ["a/b", "a\\b", "a#b"]) {
+      await assert.rejects(c.getItem(id, "item"), {
+        message: `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+      });
+    }
+  });
+
+  test("getItem: rejects IDs exceeding 1023 bytes", async () => {
+    const c = await getContainer();
+    await assert.rejects(c.getItem("a".repeat(1024), "item"), {
+      message: "Item ID exceeds the maximum allowed length of 1023 bytes.",
+    });
+  });
+
+  test("upsertItem: rejects item with invalid ID", async () => {
+    const c = await getContainer();
+    await assert.rejects(
+      c.upsertItem({ id: "a/b", pkey: "item", val: 1, _ts: 0 }),
+      {
+        message: `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+      },
+    );
+  });
+
+  test("deleteItem: rejects invalid ID", async () => {
+    const c = await getContainer();
+    await assert.rejects(c.deleteItem("a/b", "item"), {
+      message: `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+    });
+  });
 });

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -302,6 +302,39 @@ describe("DB: Container", () => {
     logCounts({ ag: 1 });
   });
 
+  test("getCountBy: groups items by nested property path", async () => {
+    type LocationEntry = {
+      id: string;
+      pkey: string;
+      location: { code: string };
+    };
+    const locationData: LocationEntry[] = [
+      { id: "1", pkey: "a", location: { code: "US" } },
+      { id: "2", pkey: "a", location: { code: "US" } },
+      { id: "3", pkey: "b", location: { code: "CA" } },
+    ];
+    const containerMap = await connectDB({
+      ...connectOptions,
+      mockDBData: { mockContainer: locationData },
+    });
+    const c = containerMap["mockContainer"] as Container<LocationEntry>;
+    const result = await c.getCountBy("location.code");
+    assert.deepEqual(result, [
+      { name: "US", count: 2 },
+      { name: "CA", count: 1 },
+    ]);
+    logCounts({ ag: 1 });
+  });
+
+  test("getCountBy: rejects invalid property paths", async () => {
+    const c = await getContainer();
+    for (const invalid of [".a", "a.", "a..b", "a b", "a/b"]) {
+      await assert.rejects(c.getCountBy(invalid), {
+        message: `Invalid property "${invalid}". Only 'A-Za-z0-9_' allowed.`,
+      });
+    }
+  });
+
   test("query: custom filter takes precedence over built-in", async () => {
     // Built-in would return all 3 items for val > 100; custom filter ignores the param and only passes val > 400.
     const customFilter: MockQueryDef = {

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -365,7 +365,7 @@ describe("DB: Container", () => {
     const c = await getContainer();
     for (const invalid of [".a", "a.", "a..b", "a b", "a/b"]) {
       await assert.rejects(c.getCountBy(invalid), {
-        message: `Invalid property "${invalid}". Only 'A-Za-z0-9_' allowed.`,
+        message: `Invalid property path "${invalid}". Only A-Za-z0-9_ identifiers separated by '.' are allowed.`,
       });
     }
   });

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -464,9 +464,9 @@ describe("DB: Container", () => {
 
   test("getItem: rejects IDs with forbidden characters", async () => {
     const c = await getContainer();
-    for (const id of ["a/b", "a\\b", "a#b"]) {
+    for (const id of ["a/b", "a\\b", "a#b", "a?b", "a%b"]) {
       await assert.rejects(c.getItem(id, "item"), {
-        message: `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+        message: `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
       });
     }
   });
@@ -483,7 +483,7 @@ describe("DB: Container", () => {
     await assert.rejects(
       c.upsertItem({ id: "a/b", pkey: "item", val: 1, _ts: 0 }),
       {
-        message: `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+        message: `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
       },
     );
   });
@@ -491,7 +491,7 @@ describe("DB: Container", () => {
   test("deleteItem: rejects invalid ID", async () => {
     const c = await getContainer();
     await assert.rejects(c.deleteItem("a/b", "item"), {
-      message: `Item ID contains an invalid character ('/', '\\', or '#'). These are not allowed in Cosmos DB item IDs.`,
+      message: `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
     });
   });
 });

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -131,6 +131,16 @@ describe("DB: Container", () => {
   );
 
   test(
+    "getCount: with partition key",
+    testSuccess(async (c) => c.getCount(undefined, "item"), mockDB.length),
+  );
+
+  test(
+    "getCount: with partition key (no match)",
+    testSuccess(async (c) => c.getCount(undefined, "nonexistent"), 0),
+  );
+
+  test(
     "query: VALUE COUNT(1) is case-insensitive",
     testSuccess(
       async (c) =>
@@ -211,6 +221,31 @@ describe("DB: Container", () => {
     testSuccess(
       async (c) => c.query<Entry>(new Query().whereCondition("val", ">", 456)),
       mockDB.filter((item) => item.val > 456),
+    ),
+  );
+
+  test(
+    "query: IN operator filters correctly",
+    testSuccess(
+      async (c) =>
+        c.query<Entry>(new Query().whereCondition("id", "IN", ["1", "3"])),
+      mockDB.filter((item) => item.id === "1" || item.id === "3"),
+    ),
+  );
+
+  test(
+    "query: orderBy ASC",
+    testSuccess(
+      async (c) => c.query<Entry>(new Query().orderBy("val")),
+      [...mockDB].sort((a, b) => a.val - b.val),
+    ),
+  );
+
+  test(
+    "query: orderBy DESC",
+    testSuccess(
+      async (c) => c.query<Entry>(new Query().orderBy("val", "DESC")),
+      [...mockDB].sort((a, b) => b.val - a.val),
     ),
   );
 
@@ -386,11 +421,22 @@ describe("DB: Container", () => {
   test(
     "upsertItem: success",
     testSuccess(
-      async (c) =>
-        c.upsertItem({ id: "1", pkey: "item", val: 999, _ts: 1234567899 }),
-      undefined,
+      async (c) => {
+        const item = { id: "1", pkey: "item", val: 999, _ts: 1234567899 };
+        return c.upsertItem(item);
+      },
+      { id: "1", pkey: "item", val: 999, _ts: 1234567899 },
     ),
   );
+
+  test("upsertItem: returns the upserted item", async () => {
+    const c = await getContainer();
+    const item = { id: "new", pkey: "item", val: 42, _ts: 0 };
+    const result = await c.upsertItem(item);
+    assert.deepEqual(result, item);
+    const fetched = await c.getItem("new", "item");
+    assert.deepEqual(fetched, item);
+  });
 
   test(
     "upsertItem: error",

--- a/packages/cosmosdb/test/mockDbData.test.ts
+++ b/packages/cosmosdb/test/mockDbData.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, mock, test } from "node:test";
+import { loadMockDBData } from "../src/mockDbData.ts";
+
+describe("DB: loadMockDBData", () => {
+  describe("returns undefined when no sources configured", () => {
+    const emptyCases: [string, object][] = [
+      ["no options", {}],
+      ["empty strings", { mockDataJson: "", mockDataPath: "" }],
+      ["whitespace strings", { mockDataJson: "  ", mockDataPath: "  " }],
+    ];
+
+    emptyCases.forEach(([label, options]) => {
+      test(label, () => {
+        assert.equal(loadMockDBData(options), undefined);
+      });
+    });
+  });
+
+  describe("inline JSON", () => {
+    test("parses valid JSON object", () => {
+      const data = { users: [{ id: "1", pkey: "a" }] };
+      const result = loadMockDBData({ mockDataJson: JSON.stringify(data) });
+      assert.deepEqual(result, data);
+    });
+
+    test("throws on invalid JSON", () => {
+      assert.throws(
+        () => loadMockDBData({ mockDataJson: "not-json" }),
+        /Invalid Cosmos DB mock data JSON in mockDataJson/,
+      );
+    });
+
+    test("throws when JSON is an array", () => {
+      assert.throws(
+        () => loadMockDBData({ mockDataJson: "[]" }),
+        /must be a JSON object keyed by container name/,
+      );
+    });
+
+    test("throws when JSON is a primitive", () => {
+      assert.throws(
+        () => loadMockDBData({ mockDataJson: "42" }),
+        /must be a JSON object keyed by container name/,
+      );
+    });
+  });
+
+  describe("file path", () => {
+    let readFileSyncMock: ReturnType<typeof mock.method>;
+
+    beforeEach(() => {
+      readFileSyncMock = mock.method(fs, "readFileSync", () =>
+        JSON.stringify({ orders: [{ id: "2", pkey: "b" }] }),
+      );
+    });
+
+    afterEach(() => {
+      readFileSyncMock.mock.restore();
+    });
+
+    test("reads and parses file", () => {
+      const result = loadMockDBData({ mockDataPath: "/data/mock-data.json" });
+      assert.deepEqual(result, { orders: [{ id: "2", pkey: "b" }] });
+      assert.equal(readFileSyncMock.mock.calls.length, 1);
+    });
+
+    test("throws on file read error", () => {
+      readFileSyncMock.mock.mockImplementation(() => {
+        throw new Error("file not found");
+      });
+      assert.throws(
+        () => loadMockDBData({ mockDataPath: "/data/missing.json" }),
+        /file not found/,
+      );
+    });
+
+    test("throws when file JSON is an array", () => {
+      readFileSyncMock.mock.mockImplementation(() => "[]");
+      assert.throws(
+        () => loadMockDBData({ mockDataPath: "bad.json" }),
+        /must be a JSON object keyed by container name/,
+      );
+    });
+  });
+
+  describe("merging sources", () => {
+    let readFileSyncMock: ReturnType<typeof mock.method>;
+
+    beforeEach(() => {
+      readFileSyncMock = mock.method(fs, "readFileSync", () =>
+        JSON.stringify({
+          orders: [{ id: "2", pkey: "b" }],
+          shared: [{ id: "file" }],
+        }),
+      );
+    });
+
+    afterEach(() => {
+      readFileSyncMock.mock.restore();
+    });
+
+    test("inline JSON overrides duplicate keys from file", () => {
+      const inlineData = {
+        users: [{ id: "1", pkey: "a" }],
+        shared: [{ id: "inline" }],
+      };
+      const result = loadMockDBData({
+        mockDataJson: JSON.stringify(inlineData),
+        mockDataPath: "mock-data.json",
+      });
+      assert.deepEqual(result, {
+        orders: [{ id: "2", pkey: "b" }],
+        users: [{ id: "1", pkey: "a" }],
+        shared: [{ id: "inline" }],
+      });
+    });
+  });
+});

--- a/packages/cosmosdb/test/query.test.ts
+++ b/packages/cosmosdb/test/query.test.ts
@@ -25,6 +25,18 @@ describe("DB: Query", () => {
     });
   });
 
+  test("condition: rejects invalid field path", () => {
+    assert.throws(() => Query.condition("x; DROP TABLE c--", "=", "v"), {
+      message: /Invalid property path/,
+    });
+  });
+
+  test("whereCondition: rejects invalid field path", () => {
+    assert.throws(() => new Query().whereCondition("a b", "=", "v"), {
+      message: /Invalid property path/,
+    });
+  });
+
   conditionCases.forEach(([field, operator, value, expected]) => {
     test(`WhereCondition: ${field} ${operator} ${value}`, () => {
       const query = new Query();
@@ -109,6 +121,18 @@ describe("DB: Query", () => {
     const result = new Query().orderBy("_ts").build();
     assert.equal(result.query, "SELECT * FROM c ORDER BY c._ts ASC");
     assert.deepEqual(result.parameters, []);
+  });
+
+  test("orderBy: rejects invalid field path", () => {
+    assert.throws(() => new Query().orderBy("status; DROP TABLE c--"), {
+      message: /Invalid property path/,
+    });
+  });
+
+  test("orderBy: rejects field with spaces", () => {
+    assert.throws(() => new Query().orderBy("my field"), {
+      message: /Invalid property path/,
+    });
   });
 
   test("orderBy: DESC", () => {

--- a/packages/cosmosdb/test/query.test.ts
+++ b/packages/cosmosdb/test/query.test.ts
@@ -105,6 +105,59 @@ describe("DB: Query", () => {
     assert.deepEqual(result.parameters, [{ name: "@status", value: "active" }]);
   });
 
+  test("orderBy: ASC by default", () => {
+    const result = new Query().orderBy("_ts").build();
+    assert.equal(result.query, "SELECT * FROM c ORDER BY c._ts ASC");
+    assert.deepEqual(result.parameters, []);
+  });
+
+  test("orderBy: DESC", () => {
+    const result = new Query().orderBy("_ts", "DESC").build();
+    assert.equal(result.query, "SELECT * FROM c ORDER BY c._ts DESC");
+    assert.deepEqual(result.parameters, []);
+  });
+
+  test("orderBy: multiple fields", () => {
+    const result = new Query().orderBy("status").orderBy("_ts", "DESC").build();
+    assert.equal(
+      result.query,
+      "SELECT * FROM c ORDER BY c.status ASC, c._ts DESC",
+    );
+    assert.deepEqual(result.parameters, []);
+  });
+
+  test("orderBy: with WHERE clause", () => {
+    const result = new Query()
+      .whereCondition("status", "=", "active")
+      .orderBy("_ts", "DESC")
+      .build();
+    assert.equal(
+      result.query,
+      "SELECT * FROM c WHERE (c.status = @status) ORDER BY c._ts DESC",
+    );
+    assert.deepEqual(result.parameters, [{ name: "@status", value: "active" }]);
+  });
+
+  test("whereCondition: IN operator", () => {
+    const result = new Query()
+      .whereCondition("status", "IN", ["active", "pending"])
+      .build();
+    assert.equal(
+      result.query,
+      "SELECT * FROM c WHERE (c.status IN (@status_0, @status_1))",
+    );
+    assert.deepEqual(result.parameters, [
+      { name: "@status_0", value: "active" },
+      { name: "@status_1", value: "pending" },
+    ]);
+  });
+
+  test("condition: IN generates correct clause and params", () => {
+    const [clause, params] = Query.condition("id", "IN", ["a", "b", "c"]);
+    assert.equal(clause, "c.id IN (@id_0, @id_1, @id_2)");
+    assert.deepEqual(params, { "@id_0": "a", "@id_1": "b", "@id_2": "c" });
+  });
+
   test("build: stacked clauses", () => {
     const result = new Query()
       .whereCondition("str", "=", "text")

--- a/packages/gemini/package.json
+++ b/packages/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dry-utils-gemini",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Personal, hyper-specific collection of Gemini API utilities",
   "type": "module",
   "sideEffects": false,

--- a/packages/gemini/package.json
+++ b/packages/gemini/package.json
@@ -33,9 +33,9 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier . --write",
-    "test": "node --import tsx/esm --test --test-reporter=dot test/**/*.test.ts",
-    "test-details": "node --import tsx/esm --test test/**/*.test.ts",
-    "e2e": "node --env-file=.env --import tsx/esm --test e2e/**/*.test.ts",
+    "test": "node --import tsx --test --test-reporter=dot test/**/*.test.ts",
+    "test-details": "node --import tsx --test test/**/*.test.ts",
+    "e2e": "node --env-file=.env --import tsx --test e2e/**/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "link": "npm link",
     "unlink": "npm unlink --global",

--- a/packages/gemini/package.json
+++ b/packages/gemini/package.json
@@ -44,7 +44,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@google/genai": "^1.11.0",
+    "@google/genai": "^2.3.0",
     "zod": "^4.1.3"
   },
   "devDependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -33,14 +33,14 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier . --write",
-    "test": "node --import tsx/esm --test --test-reporter=dot test/**/*.test.ts",
-    "test-details": "node --import tsx/esm --test test/**/*.test.ts",
+    "test": "node --import tsx --test --test-reporter=dot test/**/*.test.ts",
+    "test-details": "node --import tsx --test test/**/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "link": "npm link",
     "unlink": "npm unlink --global",
     "prepublishOnly": "npm run build && npm run test",
     "publish-package": "npm publish --access public",
-    "compare": "node --import tsx/esm scripts/compare.ts"
+    "compare": "node --import tsx scripts/compare.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -33,9 +33,9 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier . --write",
-    "test": "node --import tsx/esm --test --test-reporter=dot test/**/*.test.ts",
-    "test-details": "node --import tsx/esm --test test/**/*.test.ts",
-    "e2e": "node --env-file=.env --import tsx/esm --test e2e/**/*.test.ts",
+    "test": "node --import tsx --test --test-reporter=dot test/**/*.test.ts",
+    "test-details": "node --import tsx --test test/**/*.test.ts",
+    "e2e": "node --env-file=.env --import tsx --test e2e/**/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "link": "npm link",
     "unlink": "npm unlink --global",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier . --write",
-    "test": "node --import tsx/esm --test --test-reporter=dot test/**/*.test.ts",
-    "test-details": "node --import tsx/esm --test test/**/*.test.ts",
+    "test": "node --import tsx --test --test-reporter=dot test/**/*.test.ts",
+    "test-details": "node --import tsx --test test/**/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "link": "npm link",
     "unlink": "npm unlink --global",

--- a/scripts/checklist.mjs
+++ b/scripts/checklist.mjs
@@ -20,7 +20,7 @@ function npmCommand(cmd, ...args) {
 }
 
 if (!!isFull) {
-  npmCommand("update", "--min-release-age", 5);
+  npmCommand("update", "--min-release-age", 3);
   npmCommand("run", "clean");
   npmCommand("install");
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   // References
-  // - https://tduyng.com/blog/tsconfig-options-you-should-use/
-  // - https://2ality.com/2025/01/tsconfig-json.html
+  // https://tduyng.com/blog/tsconfig-options-you-should-use/
+  // https://2ality.com/2025/01/tsconfig-json.html
+  // https://github.com/tsconfig/bases
 
   "compilerOptions": {
     // [Environment Dependent]
-    // Node 22 App/Lib: ES2022, NodeNext, NodeNext
-    // Browser App    : ES2020, ESNext, node
-    "target": "ES2022",
+    // Node 24 App/Lib: es2024, NodeNext, NodeNext
+    // Browser App    : es2023, esnext, node
+    "target": "es2024",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
 
@@ -23,17 +24,6 @@
     // Perf improvements
     "incremental": true,
     "skipLibCheck": true,
-
-    // Strict typechecking, a combination of (at least)
-    // - noImplicitAny
-    // - strictNullChecks
-    // - strictFunctionTypes
-    // - strictBindCallApply
-    // - strictPropertyInitialization
-    // - noImplicitThis
-    // - alwaysStrict
-    // - useUnknownInCatchVariables
-    "strict": true,
 
     // Debugging
     "sourceMap": true,


### PR DESCRIPTION
- CosmosDB
  - Container functions reject obviously bad IDs
  - Container.getCount supports an optional partitionKey param
  - Container.getCountBy supports property paths ("c.prop.subprop") instead of just top-level properties
  - Container.upsertItem returns the item as stored (including system properties)
  - Query.orderBy for ORDER BY clause support
  - Query.condition supports IN operator
  - New loadMockDBData function to simplify loading mock data from string or file
- Gemini: @google/genai update from v1 to v2