### PR TITLE
Allow percent signs in CosmosDB item IDs

### DIFF
--- a/packages/cosmosdb/README.md
+++ b/packages/cosmosdb/README.md
@@ -179,7 +179,7 @@ const byStatus = await container.getCountBy("status");
 const byRegion = await container.getCountBy("location.regionCode");
 ```
 
-Item IDs are validated before use. IDs that are empty, contain `/`, `\`, `#`, `?`, or `%`, or exceed 1,023 bytes will throw immediately rather than failing at the service layer.
+Item IDs are validated before use. IDs that are empty, contain `/`, `\`, `#`, or `?`, or exceed 1,023 bytes will throw immediately rather than failing at the service layer. Percent signs are allowed.
 
 ### Subscribing to Logging Events
 

--- a/packages/cosmosdb/src/container.ts
+++ b/packages/cosmosdb/src/container.ts
@@ -22,21 +22,20 @@ const MAX_ID_BYTES = 1023;
 
 /**
  * Validates that a Cosmos DB item ID is safe to use.
- * Throws if the ID is empty, contains forbidden characters (`/`, `\`, `#`, `?`, `%`),
+ * Throws if the ID is empty, contains forbidden characters (`/`, `\`, `#`, `?`),
  * or exceeds 1,023 bytes.
  *
  * Forbidden characters: `/` and `\` are rejected by the service; `#` is
  * treated as a URL fragment delimiter by HTTP infrastructure; `?` introduces
- * query strings; `%` is used for percent-encoding. None of these are allowed
- * in IDs used in REST paths.
+ * query strings. None of these are allowed in IDs used in REST paths.
  */
 function validateItemId(id: string): void {
   if (!id) {
     throw new Error("Item ID must not be empty.");
   }
-  if (/[/\\#?%]/.test(id)) {
+  if (/[/\\#?]/.test(id)) {
     throw new Error(
-      `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
+      `Item ID contains an invalid character ('/', '\\', '#', or '?'). These are not allowed in Cosmos DB item IDs.`,
     );
   }
   if (Buffer.byteLength(id, "utf8") > MAX_ID_BYTES) {

--- a/packages/cosmosdb/test/container.test.ts
+++ b/packages/cosmosdb/test/container.test.ts
@@ -438,6 +438,15 @@ describe("DB: Container", () => {
     assert.deepEqual(fetched, item);
   });
 
+  test("item operations: allow IDs containing percent signs", async () => {
+    const c = await getContainer();
+    const item = { id: "50%off", pkey: "item", val: 42, _ts: 0 };
+    assert.deepEqual(await c.upsertItem(item), item);
+    assert.deepEqual(await c.getItem(item.id, item.pkey), item);
+    await c.deleteItem(item.id, item.pkey);
+    assert.equal(await c.getItem(item.id, item.pkey), undefined);
+  });
+
   test(
     "upsertItem: error",
     testError(async (c) =>
@@ -464,9 +473,9 @@ describe("DB: Container", () => {
 
   test("getItem: rejects IDs with forbidden characters", async () => {
     const c = await getContainer();
-    for (const id of ["a/b", "a\\b", "a#b", "a?b", "a%b"]) {
+    for (const id of ["a/b", "a\\b", "a#b", "a?b"]) {
       await assert.rejects(c.getItem(id, "item"), {
-        message: `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
+        message: `Item ID contains an invalid character ('/', '\\', '#', or '?'). These are not allowed in Cosmos DB item IDs.`,
       });
     }
   });
@@ -483,7 +492,7 @@ describe("DB: Container", () => {
     await assert.rejects(
       c.upsertItem({ id: "a/b", pkey: "item", val: 1, _ts: 0 }),
       {
-        message: `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
+        message: `Item ID contains an invalid character ('/', '\\', '#', or '?'). These are not allowed in Cosmos DB item IDs.`,
       },
     );
   });
@@ -491,7 +500,7 @@ describe("DB: Container", () => {
   test("deleteItem: rejects invalid ID", async () => {
     const c = await getContainer();
     await assert.rejects(c.deleteItem("a/b", "item"), {
-      message: `Item ID contains an invalid character ('/', '\\', '#', '?', or '%'). These are not allowed in Cosmos DB item IDs.`,
+      message: `Item ID contains an invalid character ('/', '\\', '#', or '?'). These are not allowed in Cosmos DB item IDs.`,
     });
   });
 });


### PR DESCRIPTION
### Motivation
- The ID validation was overly aggressive and rejected `%` even though percent signs should be allowed in item IDs.
- Tests and error messages referenced `%` as forbidden which caused valid IDs containing `%` to fail.

### Description
- Removed `%` from the forbidden-character regex and updated the JSDoc and error message in `packages/cosmosdb/src/container.ts` to only reject `/`, `\`, `#`, and `?`.
- Added a regression test `item operations: allow IDs containing percent signs` to `packages/cosmosdb/test/container.test.ts` to verify upsert/get/delete work with IDs containing `%`.
- Updated existing tests that asserted the old error message and rejected-character lists to remove `%` from their expectations.
- Changes touch `packages/cosmosdb/src/container.ts` and `packages/cosmosdb/test/container.test.ts`.

### Testing
- Ran `npm run test --workspace=dry-utils-cosmosdb` and the CosmosDB test suite passed successfully.
- Ran full repository checks with `npm run pre-checkin` which completed (lint, format, tests, and build all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305e1b4b2c83339749f679780cc226)